### PR TITLE
Background sending to Kubernetes-based RabbitMQ

### DIFF
--- a/releasenotes/notes/background-thread-notifier-21b36a5f5c8dec0e.yaml
+++ b/releasenotes/notes/background-thread-notifier-21b36a5f5c8dec0e.yaml
@@ -8,5 +8,8 @@ features:
     notifications will be queued for delivery in a single thread.
     Set ``send_queue_size`` to customize the length of this delivery
     queue (default size 1000).
+    Set ``send_timeout`` in seconds (default 10.0) to customize how
+    long to wait for a notification to be sent before trying again
+    in a new thread.
   - Introduced option to customize the logging level using the
     ``log_level`` option (default WARNING).


### PR DESCRIPTION
The normal oslo.messaging retry logic does not work when RabbitMQ is run as a Kubernetes service.
This is because the K8S service proxy does not always close the socket when the RabbitMQ container dies, and the oslo.messaging logic expects a closed socket before retrying.
Therefore we introduce here another thread to handle the actual event sending, separate to the queue processing thread. The queue processing thread waits for the event sending thread to indicate success, but in the event of a timeout it will spawn a new event-sending thread which will establish a new socket to the K8S service proxy and its new RabbitMQ container.

Change-Id: I223eaad08bd22744dbd304e3fd3ecceaba347b6e